### PR TITLE
Add patch for magento 2 issue 12298

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,14 @@
                         "100.*"
                     ]
                 }
+            },
+            "magento/module-braintree": {
+                "Only loop through braintree configs if it is an array": {
+                    "source" : "patches/Magento_Braintree/magento2-issue-12298.patch",
+                    "version" : [
+                        "102.*"
+                    ]
+                }
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
                 "Only loop through braintree configs if it is an array": {
                     "source" : "patches/Magento_Braintree/magento2-issue-12298.patch",
                     "version" : [
-                        "102.*"
+                        "100.2.*"
                     ]
                 }
             }

--- a/patches/Magento_Braintree/magento2-issue-12298.patch
+++ b/patches/Magento_Braintree/magento2-issue-12298.patch
@@ -1,0 +1,37 @@
+diff --git a/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php b/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
+index f68b7eca047..1b6fb25d06f 100644
+--- a/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
++++ b/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
+@@ -67,17 +67,23 @@ class CountryCreditCard extends Value
+     {
+         $value = $this->getValue();
+         $result = [];
+-        foreach ($value as $data) {
+-            if (empty($data['country_id']) || empty($data['cc_types'])) {
+-                continue;
+-            }
+-            $country = $data['country_id'];
+-            if (array_key_exists($country, $result)) {
+-                $result[$country] = $this->appendUniqueCountries($result[$country], $data['cc_types']);
+-            } else {
+-                $result[$country] = $data['cc_types'];
++        /**
++         * @see https://github.com/magento/magento2/issues/12298
++         */
++        if (is_array($value)) {
++            foreach ($value as $data) {
++                if (empty($data['country_id']) || empty($data['cc_types'])) {
++                    continue;
++                }
++                $country = $data['country_id'];
++                if (array_key_exists($country, $result)) {
++                    $result[$country] = $this->appendUniqueCountries($result[$country], $data['cc_types']);
++                } else {
++                    $result[$country] = $data['cc_types'];
++                }
+             }
+         }
++
+         $this->setValue($this->serializer->serialize($result));
+         return $this;
+     }

--- a/patches/Magento_Braintree/magento2-issue-12298.patch
+++ b/patches/Magento_Braintree/magento2-issue-12298.patch
@@ -1,7 +1,7 @@
-diff --git a/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php b/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
+diff --git a/Model/Adminhtml/System/Config/CountryCreditCard.php b/Model/Adminhtml/System/Config/CountryCreditCard.php
 index f68b7eca047..1b6fb25d06f 100644
---- a/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
-+++ b/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
+--- a/Model/Adminhtml/System/Config/CountryCreditCard.php
++++ b/Model/Adminhtml/System/Config/CountryCreditCard.php
 @@ -67,17 +67,23 @@ class CountryCreditCard extends Value
      {
          $value = $this->getValue();


### PR DESCRIPTION
When the magento config is dumped in version 2.2.x and braintree config
is empty a fatal error is thrown when trying to foreach through it.

see https://github.com/magento/magento2/issues/12298