### PR TITLE
Magento2 issue 13929

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,14 @@
                     ]
                 }
             },
+            "magento/framework": {
+                "Allow for uploads to media directory if it is a symlink https://github.com/magento/magento2/issues/13929": {
+                    "source" : "patches/Magento_Framework/13929_2.2.3_directory_resolver_composer_v1.patch",
+                    "version" : [
+                        "100.2.*"
+                    ]
+                }
+            },
             "magento/module-braintree": {
                 "Only loop through braintree configs if it is an array": {
                     "source" : "patches/Magento_Braintree/magento2-issue-12298.patch",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
                 "Allow for uploads to media directory if it is a symlink https://github.com/magento/magento2/issues/13929": {
                     "source" : "patches/Magento_Framework/13929_2.2.3_directory_resolver_composer_v1.patch",
                     "version" : [
-                        "100.*"
+                        "101.*"
                     ]
                 }
             },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
                 "Allow for uploads to media directory if it is a symlink https://github.com/magento/magento2/issues/13929": {
                     "source" : "patches/Magento_Framework/13929_2.2.3_directory_resolver_composer_v1.patch",
                     "version" : [
-                        "100.2.*"
+                        "100.*"
                     ]
                 }
             },

--- a/patches/Magento_Framework/13929_2.2.3_directory_resolver_composer_v1.patch
+++ b/patches/Magento_Framework/13929_2.2.3_directory_resolver_composer_v1.patch
@@ -1,0 +1,11 @@
+--- App/Filesystem/DirectoryResolver.php	(date 1521531005000)
++++ App/Filesystem/DirectoryResolver.php	(date 1521561205000)
+@@ -39,7 +39,7 @@
+     public function validatePath($path, $directoryConfig = DirectoryList::MEDIA)
+     {
+         $realPath = realpath($path);
+-        $root = $this->directoryList->getPath($directoryConfig);
++        $root = realpath($this->directoryList->getPath($directoryConfig));
+         
+         return strpos($realPath, $root) === 0;
+     }


### PR DESCRIPTION
```sh
[dormeo] (DOR-384/image-uploads) $ composer update space48/magento2-patches
Loading composer repositories with package information
Updating dependencies (including require-dev)                                                            
Package operations: 0 installs, 1 update, 0 removals
  - Updating space48/magento2-patches dev-magento2-issue-13929 (54aa0ff => fde8645):  Checking out fde864598d
Package sjparkinson/static-review is abandoned, you should avoid using it. Use phpro/grumphp instead.
Writing lock file
Generating autoload files
Processing patches configuration
  - Applying patches for magento/framework (1)
    ~ space48/magento2-patches: patches/Magento_Framework/13929_2.2.3_directory_resolver_composer_v1.patch [NEW]
      Allow for uploads to media directory if it is a symlink https://github.com/magento/magento2/issues/13929

Writing patch info to install file
```